### PR TITLE
Allow no ssl

### DIFF
--- a/index.js
+++ b/index.js
@@ -31,14 +31,12 @@ exports.createServer = function (opts, cb) {
                 //write(503, 'Bad sequence: already using TLS.');
                 return next();
             }
-
-			// https://tools.ietf.org/html/rfc2487
-			// 454 TLS not available due to temporary reason
-			if (!opts.pfx && (!opts.key || !opts.cert)) {
-				write(454, 'TLS is not available.');
-				return next();
-			}
-
+            // https://tools.ietf.org/html/rfc2487
+            // 454 TLS not available due to temporary reason
+            if (!opts.pfx && (!opts.key || !opts.cert)) {
+                write(454, 'TLS is not available.');
+                return next();
+            }
             clienttls = true;
             
             var tserver = tls.createServer(opts);

--- a/index.js
+++ b/index.js
@@ -12,7 +12,7 @@ exports.createServer = function (opts, cb) {
     }
     if (typeof opts === 'function') {
         cb = opts;
-        opts = {};;
+        opts = {};
     }
     if (!opts) opts = {};
     var istls = Boolean(opts.tls);
@@ -29,6 +29,14 @@ exports.createServer = function (opts, cb) {
                 //write(503, 'Bad sequence: already using TLS.');
                 return next();
             }
+
+			// https://tools.ietf.org/html/rfc2487
+			// 454 TLS not available due to temporary reason
+			if (!opts.pfx && (!opts.key || !opts.cert)) {
+				write(454, 'TLS is not available.');
+				return next();
+			}
+
             istls = true;
             
             var tserver = tls.createServer(opts);

--- a/test/start_tls.js
+++ b/test/start_tls.js
@@ -94,9 +94,53 @@ test('server upgrade to TLS', function (t) {
         stream.pipe(split()).on('data', function ondata (line) {
             if (/^\d{3}([\s-]|$)/.test(line)) {
                 var f = steps[++ix];
-                if (f) return f(line)
+                if (f) return f(line);
                 this.removeListener('data', ondata);
             }
         });
     });
+});
+
+test('server doesn\'t upgrade to TLS if there is no certificate', function (t) {
+	t.plan(4);
+	t.on('end', function () {
+		server.close();
+	});
+
+	var opts = {
+		domain: 'beep',
+		key: null,
+		cert: null
+	};
+	var server = smtp.createServer(opts, function () {});
+	server.listen(0, function () {
+		var stream = net.connect(server.address().port);
+
+		var steps = [
+			function (line) {
+				t.equal(line, '220 beep');
+				stream.write('ehlo beep\n');
+			},
+			function (line) {
+				t.equal(line, '250-beep');
+			},
+			function (line) {
+				t.equal(line, '250 STARTTLS');
+				stream.write('starttls\n');
+			},
+			function (line) {
+				t.equal(line, '454 TLS is not available.');
+				stream.write('quit\n');
+			}
+		];
+
+		var ix = -1;
+		stream.pipe(split()).on('data', function ondata (line) {
+			if (/^\d{3}([\s-]|$)/.test(line)) {
+				var f = steps[++ix];
+				if (f) return f(line);
+				this.removeListener('data', ondata);
+			}
+		});
+	});
 });

--- a/test/start_tls.js
+++ b/test/start_tls.js
@@ -102,45 +102,45 @@ test('server upgrade to TLS', function (t) {
 });
 
 test('server doesn\'t upgrade to TLS if there is no certificate', function (t) {
-	t.plan(4);
-	t.on('end', function () {
-		server.close();
-	});
+    t.plan(4);
+    t.on('end', function () {
+        server.close();
+    });
 
-	var opts = {
-		domain: 'beep',
-		key: null,
-		cert: null
-	};
-	var server = smtp.createServer(opts, function () {});
-	server.listen(0, function () {
-		var stream = net.connect(server.address().port);
+    var opts = {
+        domain: 'beep',
+        key: null,
+        cert: null
+    };
+    var server = smtp.createServer(opts, function () {});
+    server.listen(0, function () {
+        var stream = net.connect(server.address().port);
 
-		var steps = [
-			function (line) {
-				t.equal(line, '220 beep');
-				stream.write('ehlo beep\n');
-			},
-			function (line) {
-				t.equal(line, '250-beep');
-			},
-			function (line) {
-				t.equal(line, '250 STARTTLS');
-				stream.write('starttls\n');
-			},
-			function (line) {
-				t.equal(line, '454 TLS is not available.');
-				stream.write('quit\n');
-			}
-		];
+        var steps = [
+            function (line) {
+                t.equal(line, '220 beep');
+                stream.write('ehlo beep\n');
+            },
+            function (line) {
+                t.equal(line, '250-beep');
+            },
+            function (line) {
+                t.equal(line, '250 STARTTLS');
+                stream.write('starttls\n');
+            },
+            function (line) {
+                t.equal(line, '454 TLS is not available.');
+                stream.write('quit\n');
+            }
+        ];
 
-		var ix = -1;
-		stream.pipe(split()).on('data', function ondata (line) {
-			if (/^\d{3}([\s-]|$)/.test(line)) {
-				var f = steps[++ix];
-				if (f) return f(line);
-				this.removeListener('data', ondata);
-			}
-		});
-	});
+        var ix = -1;
+        stream.pipe(split()).on('data', function ondata (line) {
+            if (/^\d{3}([\s-]|$)/.test(line)) {
+                var f = steps[++ix];
+                if (f) return f(line);
+                this.removeListener('data', ondata);
+            }
+        });
+    });
 });


### PR DESCRIPTION
I noticed my ad-hoc SMTP server crashing intermittently. Turns out if you don't have an SSL key configured and client requests STARTTLS, `node-smtp-protocol` allows tls to emit an error and crash the application.

Not sure if this is desired behavior (might be), but it'd certainly be nice to at least allow server to work reliably without SSL.

This slight changes will ensure this behavior from [SMTP protocol spec](https://tools.ietf.org/html/rfc2487):

>    After the client gives the STARTTLS command, the server responds with one of the following reply codes:
>
>   220 Ready to start TLS
>   501 Syntax error (no parameters allowed)
>   **454 TLS not available due to temporary reason**

So, if there is no `cert`+`key` or `pfx` params provided for the `tls`, we return 454 instead of crashing.

