### PR TITLE
Update parser.js

### DIFF
--- a/lib/client/parser.js
+++ b/lib/client/parser.js
@@ -21,7 +21,10 @@ function ClientParser (stream) {
 ClientParser.prototype = require('../parse_data');
 
 ClientParser.prototype.getLine = function (cb) {
-    this.queue.push(cb);
+    if(this.lines.length)
+        cb(this.lines.shift());
+    else
+        this.queue.push(cb);
 };
 
 ClientParser.prototype.getUntil = function getUntil (terminal, target) {


### PR DESCRIPTION
I think this should be fixed:

```
ClientParser.prototype.getLine = function (cb) {
       this.queue.push(cb);
 };

```
because the next line may already be received and stored in lines[] array

so I propose to change it:

```
ClientParser.prototype.getLine = function (cb) {
  if(this.lines.length)
       cb(this.lines.shift());
  else
      this.queue.push(cb);
 };
```