### PR TITLE
STARTTLS: Create a new parser after replacing the stream with the cleartext one

### DIFF
--- a/lib/parse_data.js
+++ b/lib/parse_data.js
@@ -1,8 +1,8 @@
 exports.parseData = function (cb) {
     var self = this;
     var bufs = [];
-    
-    self.stream.on('data', function ondata (buf, offset) {
+
+    self.stream.on('data', this._ondatalistener = function ondata (buf, offset) {
         if (offset === undefined) offset = 0;
         
         if (self.bytes) {

--- a/lib/server/parser.js
+++ b/lib/server/parser.js
@@ -48,4 +48,11 @@ ServerParser.prototype.parseLines = function (cb) {
         }
         else cb(null, code, [ m[3] ]);
     });
-}
+};
+
+ServerParser.prototype.destroy = function () {
+    if (this._ondatalistener) {
+        this.stream.removeListener('data', this._ondatalistener);
+        this._ondatalistener = null;
+    }
+};

--- a/lib/server/proto.js
+++ b/lib/server/proto.js
@@ -25,16 +25,8 @@ function Client (stream) {
         }
     ];
     self._writeQueue = [];
-    
-    parser(stream, function (err, code, lines) {
-        if (!self.queue.length) return;
-        
-        var cb = self.queue.shift();
-        if (cb) cb(err, code, lines);
-        
-        self._nextWrite();
-    });
-    
+    self._initializeParser();
+
     self.on('newListener', function(event, listener) {
 
         if (event === 'greeting' && this.greeting) {
@@ -47,6 +39,19 @@ function Client (stream) {
 }
 
 util.inherits(Client, EventEmitter);
+
+Client.prototype._initializeParser = function () {
+    var self = this;
+
+    this._parser = parser(self.stream, function (err, code, lines) {
+        if (!self.queue.length) return;
+
+        var cb = self.queue.shift();
+        if (cb) cb(err, code, lines);
+
+        self._nextWrite();
+    });
+};
 
 Client.prototype._nextWrite = function next () {
     var self = this;
@@ -189,7 +194,11 @@ Client.prototype.startTLS = function (opts, cb) {
         
         self.stream = tls.connect(opts, function (err) {
             if (err) self.emit('error', err)
-            else self.emit('tls')
+            else {
+                self._parser.destroy();
+                self._initializeParser();
+                self.emit('tls');
+            }
         });
         self.stream.on('error', function (err) {
             self.emit('error', err);


### PR DESCRIPTION
Previously no parser was attached to the cleartext stream after TLS had been negotiated on top of the old stream, so no command callbacks would be called from that point on.